### PR TITLE
ログインが必要なコントローラーのテスト

### DIFF
--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -9,4 +9,16 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
       delete event_url(event)
     end
   end
+
+  test '自分以外が作成したイベントは削除不可能' do
+    event_owner = FactoryBot.create(:user)
+    event = FactoryBot.create(:event, owner: event_owner)
+    sign_in_user = FactoryBot.create(:user)
+    sign_in_as(sign_in_user)
+    assert_difference('Event.count', 0) do
+      assert_raises(ActiveRecord::RecordNotFound) do
+        delete event_url(event)
+      end
+    end
+  end
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,7 +1,12 @@
 require "test_helper"
 
 class EventsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test '自分の作成したイベントは削除可能' do
+    event_owner = FactoryBot.create(:user)
+    event = FactoryBot.create(:event, owner: event_owner)
+    sign_in_as(event_owner)
+    assert_difference('Event.count', -1) do
+      delete event_url(event)
+    end
+  end
 end

--- a/test/helpers/sign_in_helper.rb
+++ b/test/helpers/sign_in_helper.rb
@@ -7,12 +7,22 @@ module SignInHelper
       info: {
         nickname: user.name,
         image: user.image_url })
-    visit root_url
-    click_on 'GitHubでログイン'
+    if respond_to?(:visit)
+      visit root_url
+      click_on 'GitHubでログイン'
+    elsif respond_to?(:get)
+      get '/auth/github/callback'
+    else
+      raise NotImplementedError
+    end
     @current_user = user
   end
 
   def current_user
     @current_user
   end
+end
+
+class ActionDispatch::IntegrationTest
+  include SignInHelper
 end


### PR DESCRIPTION
###該当Issue
#22

### やったこと
- ログインヘルパーを機能テスト向けに拡張
- ログインが必要なコントローラーテスト
  - ownerは自分のイベントを削除可能
  - owner以外はイベント削除負荷
